### PR TITLE
Enable logging to stdout

### DIFF
--- a/resources/logs.py
+++ b/resources/logs.py
@@ -22,9 +22,10 @@ if settings.DEBUG_MODE:
 else:
     logger.setLevel(logging.INFO)
 """
-if "--log-to-stdout" in sys.argv:
-    handler = logging.StreamHandler(sys.stdout)
-else:
-    handler = logging.handlers.TimedRotatingFileHandler(filename=settings.LOG_FILE,when='D',interval=1, encoding='utf-8', utc=True)
+handler = logging.handlers.TimedRotatingFileHandler(filename=settings.LOG_FILE,when='D',interval=1, encoding='utf-8', utc=True)
 handler.setFormatter(logging.Formatter('%(asctime)s:%(levelname)s:%(name)s: %(message)s'))
 logger.addHandler(handler)
+if "--log-to-stdout" in sys.argv:
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(logging.Formatter('%(asctime)s:%(levelname)s:%(name)s: %(message)s'))
+    logger.addHandler(stream_handler)

--- a/resources/logs.py
+++ b/resources/logs.py
@@ -4,6 +4,7 @@
 import logging
 import logging.handlers
 import os
+import sys
 
 from resources import settings
 
@@ -21,6 +22,9 @@ if settings.DEBUG_MODE:
 else:
     logger.setLevel(logging.INFO)
 """
-handler = logging.handlers.TimedRotatingFileHandler(filename=settings.LOG_FILE,when='D',interval=1, encoding='utf-8', utc=True)
+if "--log-to-stdout" in sys.argv:
+    handler = logging.StreamHandler(sys.stdout)
+else:
+    handler = logging.handlers.TimedRotatingFileHandler(filename=settings.LOG_FILE,when='D',interval=1, encoding='utf-8', utc=True)
 handler.setFormatter(logging.Formatter('%(asctime)s:%(levelname)s:%(name)s: %(message)s'))
 logger.addHandler(handler)


### PR DESCRIPTION
Implements logging to the standard output. Useful when operating with systemd or docker.

### Usage
Start the bot with the `--log-to-stdout` flag.
