### PR TITLE
Update hunt.py to remove extra 'P' in multiplier for area 0

### DIFF
--- a/cogs/hunt.py
+++ b/cogs/hunt.py
@@ -355,7 +355,7 @@ class HuntCog(commands.Cog):
                     time_left_seconds *= settings.POTION_FLASK_MULTIPLIER
                     
                 if together and partner_christmas_area:
-                    time_left_seconds_partner_hunt *= settings.CHRISTMAS_AREA_MULTIPLIERP
+                    time_left_seconds_partner_hunt *= settings.CHRISTMAS_AREA_MULTIPLIER
                 if together and partner is not None:
                     if partner.round_card_active:
                         time_left_seconds_partner_hunt *= settings.ROUND_CARD_MULTIPLIER                    


### PR DESCRIPTION
partner hunting was not working in area0 for reminders, because MULTIPLIERP does not exist in resources/settings.py Removed the extra P to use the multiplier listed