### PR TITLE
Update auto_flex.py to account for commas in work item drops

### DIFF
--- a/cogs/auto_flex.py
+++ b/cogs/auto_flex.py
@@ -1233,7 +1233,7 @@ class AutoFlexCog(commands.Cog):
                         await errors.log_error('Couldn\'t find auto flex data in work message.', message)
                         return
                     user_name = match.group(1)
-                    item_amount = int(match.group(2))
+                    item_amount = int(match.group(2).replace(',', ''))
                     item_name = match.group(4).lower().replace('**','').strip()
                     if item_name not in item_events: return
                     event = item_events[item_name]


### PR DESCRIPTION
autoflexing on working drops that are >=5 digits fails. 

added a regex to strip commas` item_amount = int(match.group(2).replace(',', ''))
`
however, i only did this because you specified init. If its not needed than I suggest following the consistent

`item_amount = match.group(2)`