### PR TITLE
Update boosts.py to look for time potion active on all time travels

### DIFF
--- a/cogs/boosts.py
+++ b/cogs/boosts.py
@@ -156,10 +156,11 @@ class BoostsCog(commands.Cog):
                 if user_settings.reactions_enabled and user_settings.alert_boosts.enabled:
                     await message.add_reaction(emojis.NAVI)
 
-            # Tell user whether time potion is active on super time travel
+            # Tell user whether time potion is active on time travel
             search_strings_author = [
                 "— super time travel", #All languages
                 "— time jump", #All languages
+                "— time travel", #All languages
             ]
             search_strings_description = [
                 "are you sure", #English


### PR DESCRIPTION
The game has shifted to where ascended players may find themselves using time potions on a regular basis before TT25 or Super Time Travel.

Add time travel to the search string to account for the dynamic gameplay.